### PR TITLE
fix: Alexandria [1, (..) => ..] citation rendering

### DIFF
--- a/src/bookly.typ
+++ b/src/bookly.typ
@@ -60,7 +60,7 @@
 
 
   // References
-  set ref(supplement: it => none)
+  set ref(supplement: none)
 
   // Citations
   show cite: it => {
@@ -150,3 +150,4 @@
 
   body
 }
+


### PR DESCRIPTION
resolves #11 

before:
<img width="369" height="69" alt="image" src="https://github.com/user-attachments/assets/505e02f2-5f33-4146-975f-20b67401d632" />

after:
<img width="207" height="93" alt="image" src="https://github.com/user-attachments/assets/fdf05d79-497f-4373-bcf5-dbbc3962e973" />


```typst
#import "src/bookly.typ": *
#import "@preview/alexandria:0.2.2": *

#show: bookly.with(title: "This is a Title", author: "Author", theme: classic, tufte: false)

#show: alexandria(prefix: "m:", read: path => read(path))

foo @m:test @m:test2

#bibliographyx(title: "Bibliography", full: true, bytes(```yaml
  test:
    type: article
    author: Author, A.
    date: 2025
    title: This is a Test
  test2:
    type: article
    author: Bauthor, B.
    date: 2025
    title: This is also a Test
  ```.text))
  ```