### PR TITLE
fix: update listoffigures and listoftables to maintain outline state

### DIFF
--- a/src/bookly-outlines.typ
+++ b/src/bookly-outlines.typ
@@ -16,7 +16,7 @@
 }
 
 // List of figures
-#let listoffigures = {
+#let listoffigures = context {
   show outline.entry: it => context {
     let dxl = 0%
     let dxr = 0%
@@ -25,13 +25,19 @@
       dxr = -17%
     }
     show: move.with(dx: dxl)
-    fullwidth(dx: dxr, it)
+    let entry = context {
+      let prev-outline-state = states.in-outline.get()
+      states.in-outline.update(true)
+      it
+      states.in-outline.update(prev-outline-state)
+    }
+    fullwidth(dx: dxr, entry)
   }
   outline(title: context states.localization.get().lof, target: figure.where(kind: image))
 }
 
 // List of tables
-#let listoftables = {
+#let listoftables = context {
   show outline.entry: it => context {
     let dxl = 0%
     let dxr = 0%
@@ -40,7 +46,13 @@
       dxr = -17%
     }
     show: move.with(dx: dxl)
-    fullwidth(dx: dxr, it)
+    let entry = context {
+      let prev-outline-state = states.in-outline.get()
+      states.in-outline.update(true)
+      it
+      states.in-outline.update(prev-outline-state)
+    }
+    fullwidth(dx: dxr, entry)
   }
   outline(title: context states.localization.get().lot, target: figure.where(kind: table))
 }


### PR DESCRIPTION
Scoped outline.entry inside both bookly-outlines.typ:19-58 so each list entry temporarily flips states.in-outline only while its body renders. This lets ls-caption pick the short variant for list entries without affecting figures in the body or other outlines such as the TOC/minitoc.

resolves #13 