### PR TITLE
Update paper-size in custom template

### DIFF
--- a/template/custom-theme.typ
+++ b/template/custom-theme.typ
@@ -122,7 +122,7 @@
   }
 
   set page(
-    paper: paper-size,
+    paper: states.paper-size.get(),
     header: page-header,
     footer: page-footer
   )


### PR DESCRIPTION
When using the `custom-theme.typ` there was compilation errors with `paper: paper-size`.
```
[08:32:31] compiled with errors
error: unknown variable: paper-size
    ┌─ custom-theme.typ:125:11
    │
125 │     paper: paper-size,
    │            ^^^^^^^^^^
```
It is updated to reflect to the other templates.