### PR TITLE
Add `justify-headings` parameter to `config-options`

### DIFF
--- a/src/bookly-defaults.typ
+++ b/src/bookly-defaults.typ
@@ -9,6 +9,7 @@
   isappendix: state("isappendix", false),
   isfrontmatter: state("isfrontmatter", false),
   is-toc-part: state("is-toc-part", false),
+  justify-headings: state("justify-headings", true),
   localization: state("localization"),
   num-heading: state("num-heading", "1"),
   num-pattern: state("num-pattern", "1.1."),
@@ -35,6 +36,7 @@
   par-indent: false,
   paper-size: "a4",
   show-cover-author: true,
+  justify-headings: true,
 )
 
 #let default-fonts = (

--- a/src/bookly.typ
+++ b/src/bookly.typ
@@ -42,6 +42,7 @@
   states.paper-size.update(book-options.paper-size)
   states.part-numbering.update(book-options.part-numbering)
   states.par-indent.update(book-options.par-indent)
+  states.justify-headings.update(book-options.justify-headings)
 
   // Fonts
   let bookly-fonts = default-fonts + fonts
@@ -188,6 +189,7 @@
     show: headings-on-odd-page
     it
   })
+  show heading.where(level: 1): set par(justify: false) if not book-options.justify-headings
 
   // Unnumbered sections - Thanks to @bluss (Typst universe: How to have headings without numbers in a fluent way?)
   show selector(<nonum-sec>): set heading(numbering: none)

--- a/src/themes/classic.typ
+++ b/src/themes/classic.typ
@@ -189,6 +189,7 @@
   }
 
   wideblock(side: "both")[
+    #set par(justify: false) if not states.justify-headings.get()
     #if states.part-numbering.get() != none [
       #text(size: 2.5em)[#states.localization.get().part #states.counter-part.display(states.part-numbering.get())]
     #v(1em)

--- a/src/themes/fancy.typ
+++ b/src/themes/fancy.typ
@@ -223,6 +223,7 @@
       #line(stroke: 1.75pt + states.colors.get().primary, length: mid-length)
     ]
 
+    #set par(justify: false) if not states.justify-headings.get()
     #text(size: 3em)[*#title*]
     #line(stroke: 1.75pt + states.colors.get().primary, length: top-length)
   ]

--- a/src/themes/modern.typ
+++ b/src/themes/modern.typ
@@ -302,6 +302,7 @@
   ]
 
   place(center + horizon)[
+    #set par(justify: false) if not states.justify-headings.get()
     #show: wideblock.with(side: "both")
     #box(outset: 1.25em, stroke: none, radius: 50%, fill: states.colors.get().primary)[
       #set text(fill: white, weight: "bold", size: 3em)

--- a/src/themes/obook.typ
+++ b/src/themes/obook.typ
@@ -236,6 +236,7 @@ let page-header = context {
   } else {
     none
   }
+  set par(justify: false) if not states.justify-headings.get()
   let part-title = text(size: 3em)[*#title*]
 
   align(top)[

--- a/src/themes/orly.typ
+++ b/src/themes/orly.typ
@@ -3,7 +3,7 @@
 #import "../bookly-defaults.typ": *
 
 #let orly-theme(colors: default-colors, it) = {
-    show heading.where(level:1): it => {
+  show heading.where(level:1): it => {
     if not states.open-right.get() {
       pagebreak(weak: true)
     }

--- a/src/themes/orly.typ
+++ b/src/themes/orly.typ
@@ -154,7 +154,7 @@
   }
 
   let part = [
-
+    #set par(justify: false) if not states.justify-headings.get()
     #if states.part-numbering.get() != none {
       text(size: 1.75em)[*#upper[#states.localization.get().part] #states.counter-part.display(states.part-numbering.get())*]
     } else {

--- a/src/themes/pretty.typ
+++ b/src/themes/pretty.typ
@@ -309,6 +309,7 @@
     dir: ttb,
     part-name,
     box(width: width, inset: 5em, stroke: 2pt + states.colors.get().primary, radius: 2em)[
+    #set par(justify: false) if not states.justify-headings.get()
     #set text(size: 3em)
 
     *#title*


### PR DESCRIPTION
This is one approach to solve #45. The default setting matches the current behavior. Here is the file I used for testing:

```typ
#import "@local/bookly:5.0.0": *
//#import "@preview/bookly:5.0.0": *

#show: bookly.with(
  //theme: classic, // FIXME: outline
  //theme: modern, // FIXME: outline, (part, chapter look odd though)
  //theme: fancy, // FIXME: outline
  theme: obook,
  //theme: orly, // FIXME: outline
  //theme: pretty, // height of red bar next to chapter titles is fixed only if `justify-headings: false`
  config-options: (justify-headings: false),
)

#tableofcontents

#part[Short part]

= Short chapter

#part[#lorem(20)]

= #lorem(20)

#lorem(200)
```

Some observations:

- A long part name leads to its page number being misaligned in the `#tableofcontents` for some of the themes
- Using the `modern` theme, long part and chapter titles might reach outside the red pills
- Using the `pretty` theme of `@preview/bookly:5.0.0`, the red bar next to the chapter title seems to short

Is the additional `states.justify-headings` justified? Or would it be better (enough) to just set `par(justify: false)` regardless of user preference? The code would be less complex, but one could argue about whether this modifcation would be a fix or a layout-breaking change.